### PR TITLE
Add game logic for Board cell clicks

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,13 @@
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+venv/
+.venv/
+*.egg-info/
+dist/
+build/
+
+# Environment
+.env
+.env.local

--- a/backend/models.py
+++ b/backend/models.py
@@ -62,7 +62,6 @@ class Board:
         revealed_cells = []
 
         if self.is_inbound(r, c):
-            # TODO
             cell = self.grid[r][c]
 
             if cell.is_revealed:
@@ -72,14 +71,12 @@ class Board:
                 cell.toggle_flag()
 
             if cell.is_mine:
-                # end game, reveal all
                 revealed_cells = self.reveal_all()
             else:
                 revealed_cells = self.reveal(r, c) 
 
             return revealed_cells 
         else:
-            # throw out of bounds error
             return []
 
     def reveal(self, r: int, c: int) -> list[Cell]:

--- a/backend/models.py
+++ b/backend/models.py
@@ -23,12 +23,13 @@ class Cell:
         self.neighbor_mines += 1
 
 class Board:
+    offsets = [(1, 0), (-1, 0), (0, 1), (0, -1), (1, 1), (1, -1), (-1, -1), (-1, 1)]
+
     def __init__(self, cols: int, rows: int, num_mines: int):
         self.cols = cols
         self.rows = rows
         self.num_mines = num_mines
         self.grid = [[Cell(r, c) for c in range(self.cols)] for r in range(self.rows)]
-        self.offsets = [(1, 0), (-1, 0), (0, 1), (0, -1), (1, 1), (1, -1), (-1, -1), (-1, 1)]
 
     def place_mines(self):
         all_positions = []

--- a/backend/models.py
+++ b/backend/models.py
@@ -31,12 +31,11 @@ class Board:
         self.num_mines = num_mines
         self.grid = [[Cell(r, c) for c in range(self.cols)] for r in range(self.rows)]
 
-    def place_mines(self):
-        all_positions = []
+    def get_all_positions(self) -> list[tuple[int, int]]:
+        return [(r, c) for r in range(self.rows) for c in range(self.cols)]
 
-        for r in range(self.rows):
-            for c in range(self.cols):
-                all_positions.append((r, c))
+    def place_mines(self) -> None:
+        all_positions = self.get_all_positions()
 
         mine_positions = random.sample(all_positions, self.num_mines)
         self.mine_positions = mine_positions

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,5 @@
 import random
+from typing import Optional
 
 class Cell:
     def __init__(self, x: int, y: int):
@@ -27,6 +28,7 @@ class Board:
         self.rows = rows
         self.num_mines = num_mines
         self.grid = [[Cell(r, c) for c in range(self.cols)] for r in range(self.rows)]
+        self.offsets = [(1, 0), (-1, 0), (0, 1), (0, -1), (1, 1), (1, -1), (-1, -1), (-1, 1)]
 
     def place_mines(self):
         all_positions = []
@@ -44,9 +46,7 @@ class Board:
             self.compute_neighbors(r, c)
 
     def compute_neighbors(self, r: int, c:int) -> None:
-        offsets = [(1, 0), (-1, 0), (0, 1), (0, -1), (1, 1), (1, -1), (-1, -1), (-1, 1)]
-
-        for r_offset, c_offset in offsets:
+        for r_offset, c_offset in self.offsets:
             new_r, new_c = r + r_offset, c + c_offset
 
             if self.is_inbound(r, c):
@@ -66,26 +66,51 @@ class Board:
             cell = self.grid[r][c]
 
             if cell.is_revealed:
-                # do nothing, handle later
-                return
+                return []
         
             if cell.is_flagged:
-                # remove flag
-                return
+                cell.toggle_flag()
 
             if cell.is_mine:
                 # end game, reveal all
-                self.reveal_all()
+                revealed_cells = self.reveal_all()
             else:
-                revealed_cells.append(cell)
-                cell.reveal()
-                neighbors = cell.neighbor_mines
+                revealed_cells = self.reveal(r, c) 
 
-
-            return 
+            return revealed_cells 
         else:
             # throw out of bounds error
-            return
+            return []
+
+    def reveal(self, r: int, c: int) -> list[Cell]:
+        if not self.is_inbound(r, c):
+            return []
+            
+        revealed_cells = []
+        stack = [(r, c)]
+        visited = set()
+
+        while stack:  
+            cell_row, cell_col = stack.pop()
+            
+            if (cell_row, cell_col) in visited:
+                continue
+                
+            if not self.is_inbound(cell_row, cell_col):
+                continue
+                
+            cell = self.grid[cell_row][cell_col]
+            cell.reveal()
+            revealed_cells.append(cell)
+            visited.add((cell_row, cell_col))
+
+            if cell.neighbor_mines == 0:
+                for r_offset, c_offset in self.offsets:
+                    new_row = cell_row + r_offset
+                    new_col = cell_col + c_offset
+                    stack.append((new_row, new_col))
+        
+        return revealed_cells
 
     def reveal_all(self):
         # TODO: reveal all cells on game loss

--- a/backend/models.py
+++ b/backend/models.py
@@ -43,9 +43,9 @@ class Board:
         for r, c in mine_positions:
             mine_cell = self.grid[r][c]
             mine_cell.set_mine()
-            self.compute_neighbors(r, c)
+            self.increment_neighbor_mine_counts(r, c)
 
-    def compute_neighbors(self, r: int, c:int) -> None:
+    def increment_neighbor_mine_counts(self, r: int, c:int) -> None:
         for r_offset, c_offset in self.offsets:
             new_r, new_c = r + r_offset, c + c_offset
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -19,7 +19,7 @@ class Cell:
     def set_mine(self):
         self.is_mine = True
 
-    def add_neighbor(self):
+    def increment_neighbor_mine_count(self):
         self.neighbor_mines += 1
 
 class Board:
@@ -53,7 +53,7 @@ class Board:
                 neighbor_cell = self.grid[new_r][new_c]
 
                 if not neighbor_cell.is_mine:
-                    neighbor_cell.add_neighbor() 
+                    neighbor_cell.increment_neighbor_mine_count() 
             else:
                 # throw error
                 return None

--- a/backend/models.py
+++ b/backend/models.py
@@ -73,13 +73,13 @@ class Board:
             if cell.is_mine:
                 revealed_cells = self.reveal_all()
             else:
-                revealed_cells = self.reveal(r, c) 
+                revealed_cells = self.get_revealed_cells(r, c) 
 
             return revealed_cells 
         else:
             return []
 
-    def reveal(self, r: int, c: int) -> list[Cell]:
+    def get_revealed_cells(self, r: int, c: int) -> list[Cell]:
         if not self.is_inbound(r, c):
             return []
             

--- a/backend/models.py
+++ b/backend/models.py
@@ -61,23 +61,20 @@ class Board:
     def handle_click(self, r: int, c:int) -> list[Cell]:
         revealed_cells = []
 
-        if self.is_inbound(r, c):
-            cell = self.grid[r][c]
+        cell = self.grid[r][c]
 
-            if cell.is_revealed:
-                return []
-        
-            if cell.is_flagged:
-                cell.toggle_flag()
-
-            if cell.is_mine:
-                revealed_cells = self.reveal_all()
-            else:
-                revealed_cells = self.get_revealed_cells(r, c) 
-
-            return revealed_cells 
-        else:
+        if cell.is_revealed:
             return []
+    
+        if cell.is_flagged:
+            cell.toggle_flag()
+
+        if cell.is_mine:
+            revealed_cells = self.reveal_all()
+        else:
+            revealed_cells = self.get_revealed_cells(r, c) 
+
+        return revealed_cells 
 
     def get_revealed_cells(self, r: int, c: int) -> list[Cell]:
         if not self.is_inbound(r, c):

--- a/backend/tests.py/unit/test_utils.py
+++ b/backend/tests.py/unit/test_utils.py
@@ -1,0 +1,1 @@
+import pytest

--- a/backend/tests.py/unit/test_utils.py
+++ b/backend/tests.py/unit/test_utils.py
@@ -1,1 +1,0 @@
-import pytest

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -49,12 +49,12 @@ class TestReveal:
         revealed = empty_board.reveal(row, col)
         assert revealed == []
 
-    # def test_reveal_visited_cells(self, empty_board):
-    #     """Verify cells aren't revealed multiple times"""
-    #     # First reveal
-    #     first_revealed = empty_board.reveal(0, 0)
-    #     first_coords = {(cell.x, cell.y) for cell in first_revealed}
+    def test_reveal_visited_cells(self, empty_board):
+        """Verify cells aren't revealed multiple times"""
+        # First reveal
+        first_revealed = empty_board.handle_click(0, 0)
+        print(first_revealed)
         
-    #     # Second reveal of already revealed area
-    #     second_revealed = empty_board.reveal(0, 0)
-    #     assert len(second_revealed) == 0
+        # Second reveal of already revealed area
+        second_revealed = empty_board.handle_click(0, 0)
+        assert len(second_revealed) == 0

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -1,0 +1,60 @@
+import pytest
+from backend.models import Board
+
+class TestReveal:
+    @pytest.fixture
+    def board_3x3(self) -> Board:
+        board = Board(3, 3, 1)
+        board.grid[1][1].set_mine()
+        for r in range(3):
+            for c in range(3):
+                if (r, c) != (1, 1):
+                    board.grid[r][c].neighbor_mines = 1
+        return board
+    
+    @pytest.fixture
+    def empty_board(self) -> Board:
+        return Board(3, 3, 0)
+
+    def test_reveal_single_numbered_cell(self, board_3x3):
+        """Verify revealing a cell with neighbors only reveals that cell"""
+        revealed = board_3x3.reveal(0, 0)
+        
+        assert len(revealed) == 1
+        assert revealed[0].x == 0 and revealed[0].y == 0
+        assert revealed[0].neighbor_mines == 1
+        assert revealed[0].is_revealed
+
+    def test_reveal_flood_fill(self, empty_board):
+        """Verify flood fill behavior on empty board"""
+        revealed = empty_board.reveal(0, 0)
+        
+        # Should reveal all cells since there are no mines/numbers
+        assert len(revealed) == 9
+        
+        # Verify all cells in the grid are revealed
+        for row in empty_board.grid:
+            for cell in row:
+                assert cell.is_revealed
+
+    @pytest.mark.parametrize("coords", [
+        (-1, 0),  # left edge
+        (3, 0),   # right edge
+        (0, -1),  # top edge
+        (0, 3),   # bottom edge
+    ])
+    def test_reveal_out_of_bounds(self, empty_board, coords):
+        """Verify out of bounds handling"""
+        row, col = coords
+        revealed = empty_board.reveal(row, col)
+        assert revealed == []
+
+    # def test_reveal_visited_cells(self, empty_board):
+    #     """Verify cells aren't revealed multiple times"""
+    #     # First reveal
+    #     first_revealed = empty_board.reveal(0, 0)
+    #     first_coords = {(cell.x, cell.y) for cell in first_revealed}
+        
+    #     # Second reveal of already revealed area
+    #     second_revealed = empty_board.reveal(0, 0)
+    #     assert len(second_revealed) == 0


### PR DESCRIPTION
**Summary** 

Implements core game interaction logic upon user clicking a Board cell 

- adds game state validation to prevent out of bounds moves
- sets appropriate cell flags on click
- reveals single or multiple cells according to Minesweeper rules

**Testing**

- adds new unit test
- tests out of bounds edge case
- tests case where a user might click on a revealed cell multiple times
- run tests with `python -m pytest`

**To Do**

- add logic for when player loses the game, revealing all squares
- add error classes for better HTTP responses